### PR TITLE
add teams to codeonwers file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,11 @@
 # The CODEOWNERS are managed via a GitHub team, but the current list is (in alphabetical order):
 #
+
+*       @sigstore/core-team @sigstore/sigstore-blog-maintainers
+
 # lukehinds
-# rchaganti 
+# trevrosen
+# bobcallaway
+# SantiagoTorres
+# priyawadhwa
+# rchaganti


### PR DESCRIPTION

#### Summary
- add teams to codeonwers file

Related to https://github.com/sigstore/sigstore-blog/issues/5