### PR TITLE
FIX: npm blogpost is not a draft anymore

### DIFF
--- a/content/npm-public-beta.md
+++ b/content/npm-public-beta.md
@@ -2,7 +2,7 @@
 title = "Sigstore Support in NPM launches for Public Beta"
 date = "2023-04-19"
 tags = ["sigstore","npm","security","node"]
-draft = true
+draft = false
 author = "The Sigstore Techincal Steering Committee"
 type = "post"
 +++


### PR DESCRIPTION
it's not being shown because it's labeled as draft