### PR TITLE
Adding sigstore-go v0.4.0 blog post

### DIFF
--- a/content/sigstore-go-v04.md
+++ b/content/sigstore-go-v04.md
@@ -1,0 +1,18 @@
++++
+title = "sigstore-go verification and signing now in beta"
+author = "Zach Steindler (GitHub)"
+date = "2024-06-26"
+tags = ["sigstore", "go", "clients"]
+type = "post"
+draft = false
++++
+
+# sigstore-go verification and signing now in beta
+
+[sigstore-go's v0.4.0 release](https://github.com/sigstore/sigstore-go/releases/tag/v0.4.0) includes [signing support](https://github.com/sigstore/sigstore-go/blob/main/docs/signing.md), as well moving both the verification and signing API from unstable to beta.
+
+sigstore-go is used in several open source projects like the [SLSA verifier](https://github.com/slsa-framework/slsa-verifier), the [GitHub CLI](https://github.com/cli/cli), and [Stacklok Minder](https://github.com/stacklok/minder).
+
+Cosign and sigstore-go are similar in that they are both written in Go, but the main differences are that sigstore-go is not a full-fledged CLI, and that it supports the [protobuf bundle format](https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto). We're hopeful that cosign will use sigstore-go in the near future to add protobuf bundle support.
+
+Give it a try and let us know your feedback! There may be minor interface changes between now and the upcoming v1.0.0 release.


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

@haydentherapper requested it! But also to let people know that we're looking for feedback on the sigstore-go verification and signing API ahead of the upcoming v1.0.0 release.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A